### PR TITLE
Fixed deallocate/2 to not add unknown/unallocated frequencies back to Free list

### DIFF
--- a/code/chapter5/frequency.erl
+++ b/code/chapter5/frequency.erl
@@ -67,4 +67,8 @@ allocate({[Freq|Free], Allocated}, Pid) ->
 
 deallocate({Free, Allocated}, Freq) ->
   NewAllocated=lists:keydelete(Freq, 1, Allocated),
-  {[Freq|Free],  NewAllocated}.
+  case NewAllocated =:= Allocated of
+    true -> {Free,  Allocated};
+    false -> {[Freq|Free],  NewAllocated}
+  end.
+

--- a/code/chapter5/frequency.erl
+++ b/code/chapter5/frequency.erl
@@ -67,8 +67,8 @@ allocate({[Freq|Free], Allocated}, Pid) ->
 
 deallocate({Free, Allocated}, Freq) ->
   NewAllocated=lists:keydelete(Freq, 1, Allocated),
-  case NewAllocated =:= Allocated of
-    true -> {Free,  Allocated};
-    false -> {[Freq|Free],  NewAllocated}
+  case NewAllocated of
+    Allocated -> {Free,  Allocated};
+    _ -> {[Freq|Free],  NewAllocated}
   end.
 


### PR DESCRIPTION
From commit msg:
Changed deallocate/2 to only add Freq back to the list of free frequencies if
it had actually appeared in Allocated. Previously, if a frequency was passed to
deallocate/2 that didn't actually appear in Allocated, it would still be added
into the Free list. 
